### PR TITLE
"<type> is not supported" msg extended by "at field <name>"

### DIFF
--- a/model_bakery/baker.py
+++ b/model_bakery/baker.py
@@ -560,7 +560,8 @@ class Baker(object):
         elif field.__class__ in self.type_mapping:
             generator = self.type_mapping[field.__class__]
         else:
-            raise TypeError("%s is not supported by baker." % field.__class__)
+            raise TypeError("%s is not supported by baker at field '%s'." % 
+                            (field.__class__, field.name))
 
         # attributes like max_length, decimal_places are taken into account when
         # generating the value.


### PR DESCRIPTION
Providing this context info in the error message of 'generate_value()'
makes diagnosis _much_ easier in nontrivial cases.